### PR TITLE
Add Travis CI and Godoc badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # snap Plugin Utilities
+[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-utilities.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-utilities)
+[![GoDoc](https://godoc.org/github.com/intelsdi-x/snap-plugin-utilities?status.svg)](https://godoc.org/github.com/intelsdi-x/snap-plugin-utilities)
 
 Set of packages that provide tools for plugin development
 


### PR DESCRIPTION
Adds a couple badges to the README for users to easily see the build status for the `master` branch, and for users to easily get to the generated godoc documentation.